### PR TITLE
Type based plugin folders, fixes

### DIFF
--- a/cloud/src/main/java/de/redstonecloud/cloud/server/Server.java
+++ b/cloud/src/main/java/de/redstonecloud/cloud/server/Server.java
@@ -150,6 +150,16 @@ public class Server implements ICloudServer, Cacheable {
             e.printStackTrace();
         }
 
+        File rootPluginsDir = new File(RedstoneCloud.workingDir + "/plugins/" + type.name());
+        File serverPluginsDir = new File(directory + "/plugins");
+
+        if (rootPluginsDir.exists() && rootPluginsDir.isDirectory()) {
+            try {
+                FileUtils.copyDirectory(rootPluginsDir, serverPluginsDir);
+            } catch (IOException e) {
+                log.error("Failed to copy plugins for server type {}", type.name(), e);
+            }
+        }
 
         setStatus(ServerStatus.PREPARED);
     }

--- a/cloud/src/main/java/de/redstonecloud/cloud/utils/Utils.java
+++ b/cloud/src/main/java/de/redstonecloud/cloud/utils/Utils.java
@@ -245,7 +245,7 @@ public class Utils {
 
             FileUtils.copyURLToFile(URI.create(downloadUrl).toURL(),
                     new File("./templates/" + templateName + "/" + jarName));
-            log.info("{} updated successfully.\n", templateName);
+            log.info("{} updated successfully.", templateName);
 
             if (reboot) {
                 Template template = RedstoneCloud.getInstance().getServerManager().getTemplate(templateName);


### PR DESCRIPTION
This PR introduces type based plugin folders which enable people to manage their global plugins better without moving the plugin in every template.

<img width="955" height="210" alt="image" src="https://github.com/user-attachments/assets/ba4f47fb-3785-4a51-ae40-8c489a9d3b65" />

It also has a very small change in the updateSoftware function we introduced in [PR10](https://github.com/RedstoneCloud/RedstoneCloud/pull/10) where I accidentally left a "\n".